### PR TITLE
Update README.md example to comply with latest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ godot_variant GDN_EXPORT some_test_procedure(void *data, godot_array *args) {
         godot_variant_new_int(&ret, 42);
 
         godot_string s;
-        godot_string_new_unicode_data(&s, L"Hello World", 11);
+        godot_string_new_with_wide_string(&s, L"Hello World", 11);
         godot_print(&s);
 
         godot_string_destroy(&s);


### PR DESCRIPTION
I tried to compile example from README, but hit

```
➜  SimpleLibrary make build
g++ -g -fPIC -std=c99 -c src/test.c -I../godot_headers -o src/test.os
cc1plus: warning: command line option ‘-std=c99’ is valid for C/ObjC but not for C++
src/test.c: In function ‘godot_variant some_test_procedure(void*, godot_array*)’:
src/test.c:71:9: error: ‘godot_string_new_unicode_data’ was not declared in this scope; did you mean ‘godot_string_name_new_data’?
   71 |         godot_string_new_unicode_data(&s, L"Hello World", 11);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         godot_string_name_new_data
make: *** [Makefile:2: build] Error 1
```

seems like function name was changed in `gdnative/string.h`