### PR TITLE
Fix visibility for GCC

### DIFF
--- a/gdnative/gdnative.h
+++ b/gdnative/gdnative.h
@@ -53,7 +53,9 @@ extern "C" {
 #endif
 
 // This is for libraries *using* the header, NOT GODOT EXPOSING STUFF!!
-#ifdef _WIN32
+#ifdef __GNUC__
+#define GDN_EXPORT __attribute__((visibility("default")))
+#elif defined(_WIN32)
 #define GDN_EXPORT __declspec(dllexport)
 #else
 #define GDN_EXPORT


### PR DESCRIPTION
I'm building native library with CMake and found out default visibility settings make it unusable with Godot because symbols are hidden.
This PR makes exported functions visible when compiling them with GCC.