### PR TITLE
Type generic interface.

### DIFF
--- a/gdnative/pool_arrays.h
+++ b/gdnative/pool_arrays.h
@@ -162,6 +162,213 @@ typedef struct {
 extern "C" {
 #endif
 
+#if __STDC_VERSION__ >= 201112L
+
+#define godot_pool_array_new(r_dest)                                \
+    _Generic((r_dest),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_new,       \
+        godot_pool_int_array*:     godot_pool_int_array_new,        \
+        godot_pool_real_array*:    godot_pool_real_array_new,       \
+        godot_pool_string_array*:  godot_pool_string_array_new,     \
+        godot_pool_vector2_array*: godot_pool_vector2_array_new,    \
+        godot_pool_vector3_array*: godot_pool_vector3_array_new,    \
+        godot_pool_color_array*:   godot_pool_color_array_new)      \
+    ((r_dest))
+
+
+#define godot_pool_array_new_copy(r_dest, p_src)                        \
+    _Generic((r_dest),                                                  \
+        godot_pool_byte_array*:    godot_pool_byte_array_new_copy,      \
+        godot_pool_int_array*:     godot_pool_int_array_new_copy,       \
+        godot_pool_real_array*:    godot_pool_real_array_new_copy,      \
+        godot_pool_string_array*:  godot_pool_string_array_new_copy,    \
+        godot_pool_vector2_array*: godot_pool_vector2_array_new_copy,   \
+        godot_pool_vector3_array*: godot_pool_vector3_array_new_copy,   \
+        godot_pool_color_array*:   godot_pool_color_array_new_copy)     \
+    ((r_dest), (p_src))
+
+
+#define godot_pool_array_new_with_array(r_dest, p_a)                        \
+    _Generic((r_dest),                                                      \
+        godot_pool_byte_array*:    godot_pool_byte_array_new_with_array,    \
+        godot_pool_int_array*:     godot_pool_int_array_new_with_array,     \
+        godot_pool_real_array*:    godot_pool_real_array_new_with_array,    \
+        godot_pool_string_array*:  godot_pool_string_array_new_with_array,  \
+        godot_pool_vector2_array*: godot_pool_vector2_array_new_with_array, \
+        godot_pool_vector3_array*: godot_pool_vector3_array_new_with_array, \
+        godot_pool_color_array*:   godot_pool_color_array_new_with_array)   \
+    ((r_dest), (p_a))
+
+
+#define godot_pool_array_append(p_self, p_data)                         \
+    _Generic((p_self),                                                  \
+        godot_pool_byte_array*:    godot_pool_byte_array_append,        \
+        godot_pool_int_array*:     godot_pool_int_array_append,         \
+        godot_pool_real_array*:    godot_pool_real_array_append,        \
+        godot_pool_string_array*:  godot_pool_string_array_append,      \
+        godot_pool_vector2_array*: godot_pool_vector2_array_append,     \
+        godot_pool_vector3_array*: godot_pool_vector3_array_append,     \
+        godot_pool_color_array*:   godot_pool_color_array_append)       \
+    ((p_self), (p_data))
+
+
+#define godot_pool_array_append_array(p_self, p_array)                      \
+    _Generic((p_self),                                                      \
+        godot_pool_byte_array*:    godot_pool_byte_array_append_array,      \
+        godot_pool_int_array*:     godot_pool_int_array_append_array,       \
+        godot_pool_real_array*:    godot_pool_real_array_append_array,      \
+        godot_pool_string_array*:  godot_pool_string_array_append_array,    \
+        godot_pool_vector2_array*: godot_pool_vector2_array_append_array,   \
+        godot_pool_vector3_array*: godot_pool_vector3_array_append_array,   \
+        godot_pool_color_array*:   godot_pool_color_array_append_array)     \
+    ((p_self), (p_array))
+
+
+#define godot_pool_array_insert(p_self, p_idx, p_data)              \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_insert,    \
+        godot_pool_int_array*:     godot_pool_int_array_insert,     \
+        godot_pool_real_array*:    godot_pool_real_array_insert,    \
+        godot_pool_string_array*:  godot_pool_string_array_insert,  \
+        godot_pool_vector2_array*: godot_pool_vector2_array_insert, \
+        godot_pool_vector3_array*: godot_pool_vector3_array_insert, \
+        godot_pool_color_array*:   godot_pool_color_array_insert)   \
+    ((p_self), (p_idx), (p_data))
+
+
+#define godot_pool_array_invert(p_self)                             \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_invert,    \
+        godot_pool_int_array*:     godot_pool_int_array_invert,     \
+        godot_pool_real_array*:    godot_pool_real_array_invert,    \
+        godot_pool_string_array*:  godot_pool_string_array_invert,  \
+        godot_pool_vector2_array*: godot_pool_vector2_array_invert, \
+        godot_pool_vector3_array*: godot_pool_vector3_array_invert, \
+        godot_pool_color_array*:   godot_pool_color_array_invert)   \
+    ((p_self))
+
+
+#define godot_pool_array_push_back(p_self, p_data)                      \
+    _Generic((p_self),                                                  \
+        godot_pool_byte_array*:    godot_pool_byte_array_push_back,     \
+        godot_pool_int_array*:     godot_pool_int_array_push_back,      \
+        godot_pool_real_array*:    godot_pool_real_array_push_back,     \
+        godot_pool_string_array*:  godot_pool_string_array_push_back,   \
+        godot_pool_vector2_array*: godot_pool_vector2_array_push_back,  \
+        godot_pool_vector3_array*: godot_pool_vector3_array_push_back,  \
+        godot_pool_color_array*:   godot_pool_color_array_push_back)    \
+    ((p_self), (p_data))
+
+
+#define godot_pool_array_remove(p_self, p_idx)                      \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_remove,    \
+        godot_pool_int_array*:     godot_pool_int_array_remove,     \
+        godot_pool_real_array*:    godot_pool_real_array_remove,    \
+        godot_pool_string_array*:  godot_pool_string_array_remove,  \
+        godot_pool_vector2_array*: godot_pool_vector2_array_remove, \
+        godot_pool_vector3_array*: godot_pool_vector3_array_remove, \
+        godot_pool_color_array*:   godot_pool_color_array_remove)   \
+    ((p_self), (p_idx))
+
+
+#define godot_pool_array_resize(p_self, p_size)                         \
+    _Generic((p_self),                                                  \
+        godot_pool_byte_array*:    godot_pool_byte_array_resize,        \
+        godot_pool_int_array*:     godot_pool_int_array_resize,         \
+        godot_pool_real_array*:    godot_pool_real_array_resize,        \
+        godot_pool_string_array*:  godot_pool_string_array_resize,      \
+        godot_pool_vector2_array*: godot_pool_vector2_array_resize,     \
+        godot_pool_vector3_array*: godot_pool_vector3_array_resize,     \
+        godot_pool_color_array*:   godot_pool_color_array_resize)       \
+    ((p_self), (p_size))
+
+
+#define godot_pool_array_read(p_self)                               \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_read,      \
+        godot_pool_int_array*:     godot_pool_int_array_read,       \
+        godot_pool_real_array*:    godot_pool_real_array_read,      \
+        godot_pool_string_array*:  godot_pool_string_array_read,    \
+        godot_pool_vector2_array*: godot_pool_vector2_array_read,   \
+        godot_pool_vector3_array*: godot_pool_vector3_array_read,   \
+        godot_pool_color_array*:   godot_pool_color_array_read)     \
+    ((p_self))
+
+
+#define godot_pool_array_write(p_self)                              \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_write,     \
+        godot_pool_int_array*:     godot_pool_int_array_write,      \
+        godot_pool_real_array*:    godot_pool_real_array_write,     \
+        godot_pool_string_array*:  godot_pool_string_array_write,   \
+        godot_pool_vector2_array*: godot_pool_vector2_array_write,  \
+        godot_pool_vector3_array*: godot_pool_vector3_array_write,  \
+        godot_pool_color_array*:   godot_pool_color_array_write)    \
+    ((p_self))
+
+
+#define godot_pool_array_set(p_self, p_idx, p_data)                 \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_set,       \
+        godot_pool_int_array*:     godot_pool_int_array_set,        \
+        godot_pool_real_array*:    godot_pool_real_array_set,       \
+        godot_pool_string_array*:  godot_pool_string_array_set,     \
+        godot_pool_vector2_array*: godot_pool_vector2_array_set,    \
+        godot_pool_vector3_array*: godot_pool_vector3_array_set,    \
+        godot_pool_color_array*:   godot_pool_color_array_set)      \
+    ((p_self), (p_idx), (p_data))
+
+
+#define godot_pool_array_get(p_self, p_idx)                         \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_get,       \
+        godot_pool_int_array*:     godot_pool_int_array_get,        \
+        godot_pool_real_array*:    godot_pool_real_array_get,       \
+        godot_pool_string_array*:  godot_pool_string_array_get,     \
+        godot_pool_vector2_array*: godot_pool_vector2_array_get,    \
+        godot_pool_vector3_array*: godot_pool_vector3_array_get,    \
+        godot_pool_color_array*:   godot_pool_color_array_get)      \
+    ((p_self), (p_idx))
+
+
+#define godot_pool_array_size(p_self)                               \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_size,      \
+        godot_pool_int_array*:     godot_pool_int_array_size,       \
+        godot_pool_real_array*:    godot_pool_real_array_size,      \
+        godot_pool_string_array*:  godot_pool_string_array_size,    \
+        godot_pool_vector2_array*: godot_pool_vector2_array_size,   \
+        godot_pool_vector3_array*: godot_pool_vector3_array_size,   \
+        godot_pool_color_array*:   godot_pool_color_array_size)     \
+    ((p_self))
+
+
+#define godot_pool_array_empty(p_self)                              \
+    _Generic((p_self),                                              \
+        godot_pool_byte_array*:    godot_pool_byte_array_empty,     \
+        godot_pool_int_array*:     godot_pool_int_array_empty,      \
+        godot_pool_real_array*:    godot_pool_real_array_empty,     \
+        godot_pool_string_array*:  godot_pool_string_array_empty,   \
+        godot_pool_vector2_array*: godot_pool_vector2_array_empty,  \
+        godot_pool_vector3_array*: godot_pool_vector3_array_empty,  \
+        godot_pool_color_array*:   godot_pool_color_array_empty)    \
+    ((p_self))
+
+
+#define godot_pool_array_destroy(p_self)                                \
+    _Generic((p_self),                                                  \
+        godot_pool_byte_array*:    godot_pool_byte_array_destroy,       \
+        godot_pool_int_array*:     godot_pool_int_array_destroy,        \
+        godot_pool_real_array*:    godot_pool_real_array_destroy,       \
+        godot_pool_string_array*:  godot_pool_string_array_destroy,     \
+        godot_pool_vector2_array*: godot_pool_vector2_array_destroy,    \
+        godot_pool_vector3_array*: godot_pool_vector3_array_destroy,    \
+        godot_pool_color_array*:   godot_pool_color_array_destroy)      \
+    ((p_self))
+
+#endif
+
 // byte
 
 void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *r_dest);

--- a/gdnative/variant.h
+++ b/gdnative/variant.h
@@ -168,6 +168,42 @@ typedef enum godot_variant_operator {
 extern "C" {
 #endif
 
+#if __STDC_VERSION__ >= 201112L
+
+#define godot_variant_new(r_dest, p_value)                              \
+    _Generic((p_value),                                                 \
+        godot_bool: godot_variant_new_bool,                             \
+        int:      godot_variant_new_int,                                \
+        uint64_t: godot_variant_new_uint,                               \
+        int64_t:  godot_variant_new_int,                                \
+        double:   godot_variant_new_real,                               \
+        float:    godot_variant_new_real,                               \
+        godot_string*: godot_variant_new_string,                        \
+        godot_vector2*: godot_variant_new_vector2,                      \
+        godot_rect2*: godot_variant_new_rect2,                          \
+        godot_vector3*: godot_variant_new_vector3,                      \
+        godot_transform2d*: godot_variant_new_transform2d,              \
+        godot_plane*: godot_variant_new_plane,                          \
+        godot_quat*: godot_variant_new_quat,                            \
+        godot_aabb*: godot_variant_new_aabb,                            \
+        godot_basis*: godot_variant_new_basis,                          \
+        godot_transform*: godot_variant_new_transform,                  \
+        godot_color*: godot_variant_new_color,                          \
+        godot_node_path*: godot_variant_new_node_path,                  \
+        godot_rid*: godot_variant_new_rid,                              \
+        godot_object*: godot_variant_new_object,                        \
+        godot_dictionary*: godot_variant_new_dictionary,                \
+        godot_array*: godot_variant_new_array,                          \
+        godot_pool_byte_array*: godot_variant_new_pool_byte_array,      \
+        godot_pool_int_array*: godot_variant_new_pool_int_array,        \
+        godot_pool_real_array*: godot_variant_new_pool_real_array,      \
+        godot_pool_string_array*: godot_variant_new_pool_string_array,  \
+        godot_pool_vector2_array*: godot_variant_new_pool_vector2_array,\
+        godot_pool_vector3_array*: godot_variant_new_pool_vector3_array,\
+        godot_pool_color_array*: godot_variant_new_pool_color_array)    \
+    ((r_dest), (p_value))
+#endif
+
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 
 void GDAPI godot_variant_new_copy(godot_variant *r_dest, const godot_variant *p_src);


### PR DESCRIPTION
I have added a type generic to both variant and pool arrays.
This is to makes it easier to use when running in c11 or newer standards.

It's a type generic interface so a bit like a template in c++ but it's c11 instead
https://en.cppreference.com/w/c/language/generic
```c 
godot_variant ret;
// instead of this
godot_variant_new_int(&ret, 10);
// you can just say (in c11 and up)
godot_variant_new(&ret, 10);
```
I have only made interfaces where I think it would be most useful but there are a lot of other places where this could also help.
like for instance all the `operator_*` functions could have a similar interface, but I think this would need further discussion.
