### PR TITLE
Add get_buffered_amount() to WebRTCDataChannel (godot-headers)

### DIFF
--- a/api.json
+++ b/api.json
@@ -187026,6 +187026,19 @@
 				]
 			},
 			{
+				"name": "get_buffered_amount",
+				"return_type": "int",
+				"is_editor": false,
+				"is_noscript": false,
+				"is_const": true,
+				"is_reverse": false,
+				"is_virtual": false,
+				"has_varargs": false,
+				"is_from_script": false,
+				"arguments": [
+				]
+			},
+			{
 				"name": "get_id",
 				"return_type": "int",
 				"is_editor": false,

--- a/net/godot_webrtc.h
+++ b/net/godot_webrtc.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 #define GODOT_NET_WEBRTC_API_MAJOR 3
-#define GODOT_NET_WEBRTC_API_MINOR 2
+#define GODOT_NET_WEBRTC_API_MINOR 4
 
 /* Library Interface (used to set default GDNative WebRTC implementation */
 typedef struct {
@@ -107,6 +107,13 @@ typedef struct {
 
 	void *next; /* For extension? */
 } godot_net_webrtc_data_channel;
+
+/* Extensions to WebRTCDataChannel */
+typedef struct {
+	int (*get_buffered_amount)(const void *);
+
+	void *next; /* For extension? */
+} godot_net_webrtc_data_channel_ext;
 
 /* Set the default GDNative library */
 godot_error GDAPI godot_net_set_webrtc_library(const godot_net_webrtc_library *);


### PR DESCRIPTION
This updates the headers to include the new `godot_net_webrtc_data_channel_ext` struct added in https://github.com/godotengine/godot/pull/50659

This should allow PR https://github.com/godotengine/webrtc-native/pull/43 to build with support for the new method.