### PR TITLE
Update files to Godot 3.4-beta5 (`3.x` branch)

### DIFF
--- a/net/godot_net.h
+++ b/net/godot_net.h
@@ -45,7 +45,6 @@ extern "C" {
 #define GODOT_NET_API_MINOR 1
 
 typedef struct {
-
 	godot_gdnative_api_version version; /* version of our API */
 	godot_object *data; /* User reference */
 

--- a/net/godot_webrtc.h
+++ b/net/godot_webrtc.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 #define GODOT_NET_WEBRTC_API_MAJOR 3
-#define GODOT_NET_WEBRTC_API_MINOR 2
+#define GODOT_NET_WEBRTC_API_MINOR 4
 
 /* Library Interface (used to set default GDNative WebRTC implementation */
 typedef struct {
@@ -107,6 +107,13 @@ typedef struct {
 
 	void *next; /* For extension? */
 } godot_net_webrtc_data_channel;
+
+/* Extensions to WebRTCDataChannel */
+typedef struct {
+	int (*get_buffered_amount)(const void *);
+
+	void *next; /* For extension? */
+} godot_net_webrtc_data_channel_ext;
 
 /* Set the default GDNative library */
 godot_error GDAPI godot_net_set_webrtc_library(const godot_net_webrtc_library *);

--- a/videodecoder/godot_videodecoder.h
+++ b/videodecoder/godot_videodecoder.h
@@ -46,7 +46,7 @@ typedef struct
 	void *next;
 	void *(*constructor)(godot_object *);
 	void (*destructor)(void *);
-	const char *(*get_plugin_name)(void);
+	const char *(*get_plugin_name)();
 	const char **(*get_supported_extensions)(int *count);
 	godot_bool (*open_file)(void *, void *); // data struct, and a FileAccess pointer
 	godot_real (*get_length)(const void *);


### PR DESCRIPTION
Currently the `master` branch still tracks upstream `3.3` (3.3.3-stable).

We need to decide how we want to handle `3.x` (3.4) and 4.0 headers in this repo.

This PR would add current `3.x` headers to this repo's `master`, but we can also opt for creating a `3.x` branch like upstream, and go directly to 4.0 in `master`. That might be the clearest.