### PR TITLE
Create meson.build for pkg-config support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,18 @@ project('godot-headers',
   'c',
   license : 'MIT')
 
+pkgconfig = import('pkgconfig')
+
+h = [
+  'android',
+  'arvr',
+  'gdnative',
+  'nativescript',
+  'net',
+  'pluginscript',
+  'videodecoder',
+]
+
 install_headers(
   'android/godot_android.h',
   'arvr/godot_arvr.h',
@@ -42,3 +54,4 @@ install_data(
   'images/faq/set_script_dllibrary.png',
   preserve_path: true)
 
+pkgconfig.generate(subdirs: h, name: 'godot-headers', description: 'Headers for the Godot API supplied by the GDNative module')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('godot-headers',
   'c',
-  license : 'MIT')
+  license : 'MIT',
+  meson_version: '>= 1.3.0')
 
 pkgconfig = import('pkgconfig')
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,44 @@
+project('godot-headers',
+  'c',
+  license : 'MIT')
+
+install_headers(
+  'android/godot_android.h',
+  'arvr/godot_arvr.h',
+  'gdnative/aabb.h',
+  'gdnative/array.h',
+  'gdnative/basis.h',
+  'gdnative/color.h',
+  'gdnative/dictionary.h',
+  'gdnative/gdnative.h',
+  'gdnative/node_path.h',
+  'gdnative/plane.h',
+  'gdnative/pool_arrays.h',
+  'gdnative/quat.h',
+  'gdnative/rect2.h',
+  'gdnative/rid.h',
+  'gdnative/string.h',
+  'gdnative/string_name.h',
+  'gdnative/transform.h',
+  'gdnative/transform2d.h',
+  'gdnative/variant.h',
+  'gdnative/vector2.h',
+  'gdnative/vector3.h',
+  'nativescript/godot_nativescript.h',
+  'net/godot_net.h',
+  'net/godot_webrtc.h',
+  'pluginscript/godot_pluginscript.h',
+  'videodecoder/godot_videodecoder.h',
+  'gdnative_api_struct.gen.h',
+  preserve_path: true)
+
+install_data(
+  'api.json',
+  'gdnative_api.json',
+  'images/faq/create_dlscript.png',
+  'images/faq/dllibrary_create_new_dllibrary.png',
+  'images/faq/dllibrary_create_new_resource.png',
+  'images/faq/dllibrary_save_as_resource.png',
+  'images/faq/set_script_dllibrary.png',
+  preserve_path: true)
+


### PR DESCRIPTION
# Changes
- Create `/meson.build`

# Purposes
- To access godot-headers using `pkg-config`.
- To install godot-headers to system wide.